### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,15 +60,15 @@ to upgrade.
 
 ## Supported Versions
 
-Envoy AI Gateway is pre-`v1.0.0` and follows the support policy described in
-[RELEASES.md](./RELEASES.md). In short, the end of life for a given release is
-**two releases after** it was published (for example, `v0.1.0` reaches end of
-life when `v0.3.0` is released).
+Envoy AI Gateway follows the support policy described in
+[RELEASES.md](./RELEASES.md). With the general availability of `v1.0.0`, the
+`v1.x` line is the supported, stable release series, and security fixes target
+the latest `v1.x` patch release.
 
 Security fixes are applied to the `main` branch and backported to the latest
 supported release line. We strongly recommend that all users run a supported,
-up-to-date version. Reports against unsupported versions may be addressed by
-asking you to reproduce the issue on a supported version.
+up-to-date `v1.x` version. Reports against unsupported or end-of-life versions
+may be addressed by asking you to reproduce the issue on a supported version.
 
 ## Security Updates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,16 +9,11 @@ every effort to acknowledge your contributions.
 **Please do not report security vulnerabilities through public GitHub issues,
 discussions, pull requests, or any other public channel.**
 
-Instead, please report vulnerabilities privately using one of the following
-channels:
-
-1. **Preferred:** Open a
-   [GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new).
-   This allows the maintainers to triage the report and collaborate with you
-   privately, directly on GitHub.
-
-2. **Alternative:** Email the Envoy AI Gateway maintainers at
-   [envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com).
+Instead, please report vulnerabilities privately by opening a
+[GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
+("Report a vulnerability" on the repository's **Security** tab). This allows the
+maintainers to triage the report and collaborate with you privately, directly on
+GitHub.
 
 If the vulnerability relates to Envoy Proxy or Envoy Gateway (the components
 that Envoy AI Gateway is built on top of) rather than Envoy AI Gateway itself,
@@ -99,8 +94,10 @@ To minimize security risks when running Envoy AI Gateway:
 
 ## Contact
 
-If you have any questions about this security policy, please reach out to the
-maintainers listed in [MAINTAINERS.md](./MAINTAINERS.md) or email
-[envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com).
+If you have any general (non-sensitive) questions about this security policy,
+please reach out to the maintainers listed in [MAINTAINERS.md](./MAINTAINERS.md).
+To report a vulnerability, always use the private
+[GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
+flow described above rather than a public channel.
 
 Thank you for helping to keep Envoy AI Gateway and its users secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,8 @@ that Envoy AI Gateway is built on top of) rather than Envoy AI Gateway itself,
 please report it to the relevant upstream project:
 
 - Envoy Proxy: https://github.com/envoyproxy/envoy/security/advisories/new
-- Envoy Gateway: https://github.com/envoyproxy/gateway/security/advisories/new
+- Envoy Gateway: email envoy-gateway-security@googlegroups.com (see the
+  [Envoy Gateway security policy](https://github.com/envoyproxy/gateway/blob/main/SECURITY.md))
 
 ### What to Include
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,14 +67,18 @@ to upgrade.
 ## Supported Versions
 
 Envoy AI Gateway follows the support policy described in
-[RELEASES.md](./RELEASES.md). With the general availability of `v1.0.0`, the
-`v1.x` line is the supported, stable release series, and security fixes target
-the latest `v1.x` patch release.
+[RELEASES.md](./RELEASES.md), aligned with the
+[Envoy Gateway release support policy](https://gateway.envoyproxy.io/). Minor
+releases are cut on a roughly quarterly cadence, and each minor release is
+supported for **6 months** after its release date. In practice this means the
+**two most recent minor releases** (the current and the previous `v1.x` line)
+are supported at any given time.
 
-Security fixes are applied to the `main` branch and backported to the latest
-supported release line. We strongly recommend that all users run a supported,
-up-to-date `v1.x` version. Reports against unsupported or end-of-life versions
-may be addressed by asking you to reproduce the issue on a supported version.
+Security fixes are developed on the `main` branch and backported as patch
+releases to every minor release that is still within its support window. We
+strongly recommend that all users run a supported, up-to-date `v1.x` version.
+Reports against unsupported or end-of-life versions may be addressed by asking
+you to reproduce the issue on a supported version.
 
 ## Security Updates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,11 +9,16 @@ every effort to acknowledge your contributions.
 **Please do not report security vulnerabilities through public GitHub issues,
 discussions, pull requests, or any other public channel.**
 
-Instead, please report vulnerabilities privately by opening a
-[GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
-("Report a vulnerability" on the repository's **Security** tab). This allows the
-maintainers to triage the report and collaborate with you privately, directly on
-GitHub.
+Instead, please report vulnerabilities privately using one of the following
+channels:
+
+1. **Preferred:** Open a
+   [GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
+   ("Report a vulnerability" on the repository's **Security** tab). This allows
+   the maintainers to triage the report and collaborate with you privately,
+   directly on GitHub.
+2. **Alternative:** Email the Envoy AI Gateway security team at
+   [envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com).
 
 If the vulnerability relates to Envoy Proxy or Envoy Gateway (the components
 that Envoy AI Gateway is built on top of) rather than Envoy AI Gateway itself,
@@ -97,8 +102,10 @@ To minimize security risks when running Envoy AI Gateway:
 
 If you have any general (non-sensitive) questions about this security policy,
 please reach out to the maintainers listed in [MAINTAINERS.md](./MAINTAINERS.md).
-To report a vulnerability, always use the private
-[GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
-flow described above rather than a public channel.
+To report a vulnerability, always use one of the private channels described
+above — the [GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new)
+flow or the security team at
+[envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com)
+— rather than a public channel.
 
 Thank you for helping to keep Envoy AI Gateway and its users secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,106 @@
+# Security Policy
+
+The Envoy AI Gateway maintainers and community take security seriously. We
+appreciate your efforts to responsibly disclose your findings, and will make
+every effort to acknowledge your contributions.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, pull requests, or any other public channel.**
+
+Instead, please report vulnerabilities privately using one of the following
+channels:
+
+1. **Preferred:** Open a
+   [GitHub Security Advisory](https://github.com/envoyproxy/ai-gateway/security/advisories/new).
+   This allows the maintainers to triage the report and collaborate with you
+   privately, directly on GitHub.
+
+2. **Alternative:** Email the Envoy AI Gateway maintainers at
+   [envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com).
+
+If the vulnerability relates to Envoy Proxy or Envoy Gateway (the components
+that Envoy AI Gateway is built on top of) rather than Envoy AI Gateway itself,
+please report it to the relevant upstream project:
+
+- Envoy Proxy: https://github.com/envoyproxy/envoy/security/advisories/new
+- Envoy Gateway: https://github.com/envoyproxy/gateway/security/advisories/new
+
+### What to Include
+
+To help us triage and resolve the issue as quickly as possible, please include
+as much of the following information as you can:
+
+- A description of the vulnerability and its potential impact.
+- The affected version(s) of Envoy AI Gateway.
+- Steps to reproduce the issue, including any sample configuration, requests, or
+  proof-of-concept code.
+- Any known workarounds or suggested remediation.
+
+> **Note**: If your report includes data that has privacy concerns, please
+> sanitize the data prior to sharing it.
+
+## Disclosure Process
+
+After a vulnerability is reported, the maintainers will follow this process:
+
+1. **Acknowledgement** — We aim to acknowledge receipt of your report within
+   **3 business days**.
+2. **Triage** — We will investigate to validate the report, determine the
+   affected versions, and assess the severity and impact.
+3. **Fix and coordination** — We will work on a fix and coordinate a release
+   timeline with you. We aim to resolve or publicly disclose privately reported
+   issues within **90 days** of the initial report.
+4. **Release and disclosure** — Once a fix is available, we will publish the
+   patched release and an accompanying security advisory.
+
+We will keep you informed of the progress throughout the process. If you would
+like to be credited for the discovery, please let us know, and we will include
+an acknowledgement in the advisory (with your consent).
+
+Please keep the details of any reported vulnerability confidential until a fix
+has been released and the embargo has been lifted, so that users have a chance
+to upgrade.
+
+## Supported Versions
+
+Envoy AI Gateway is pre-`v1.0.0` and follows the support policy described in
+[RELEASES.md](./RELEASES.md). In short, the end of life for a given release is
+**two releases after** it was published (for example, `v0.1.0` reaches end of
+life when `v0.3.0` is released).
+
+Security fixes are applied to the `main` branch and backported to the latest
+supported release line. We strongly recommend that all users run a supported,
+up-to-date version. Reports against unsupported versions may be addressed by
+asking you to reproduce the issue on a supported version.
+
+## Security Updates
+
+Security patches and advisories are announced through:
+
+- The [GitHub Releases page](https://github.com/envoyproxy/ai-gateway/releases)
+- The [GitHub Security Advisories page](https://github.com/envoyproxy/ai-gateway/security/advisories)
+
+We recommend watching the repository and subscribing to these channels to stay
+informed about security updates.
+
+## Best Practices for Secure Usage
+
+To minimize security risks when running Envoy AI Gateway:
+
+- Run the latest supported version and apply patches promptly.
+- Follow the principle of least privilege when configuring credentials and
+  `BackendSecurityPolicy` resources, and store secrets using Kubernetes Secrets
+  (or an external secret manager) rather than in plaintext configuration.
+- Restrict network access to the control plane and management interfaces.
+- Regularly review the security-related documentation under the project
+  [docs](./site/docs/capabilities/security).
+
+## Contact
+
+If you have any questions about this security policy, please reach out to the
+maintainers listed in [MAINTAINERS.md](./MAINTAINERS.md) or email
+[envoy-ai-gateway-security@googlegroups.com](mailto:envoy-ai-gateway-security@googlegroups.com).
+
+Thank you for helping to keep Envoy AI Gateway and its users secure.


### PR DESCRIPTION
**Description**

This adds a SECURITY.md security policy for the project ahead of the v1.0 GA release.

The policy documents:

- How to privately report a vulnerability. The preferred channel is the GitHub Security Advisory "Report a vulnerability" flow, with the envoy-ai-gateway-security@googlegroups.com mailing list as an alternative. Reports for the underlying Envoy Proxy and Envoy Gateway components are redirected to their respective upstream channels.
- What to include in a report, and a note about sanitizing any data with privacy concerns.
- The disclosure process and timeline: acknowledgement, triage, fix and coordination within 90 days, then release and a published advisory.
- Supported versions, aligned with the Envoy Gateway support policy. Minor releases are cut on a roughly quarterly cadence and each minor release is supported for 6 months, so the two most recent minor releases are supported at any given time, with security fixes backported as patch releases to every minor still within its support window.
- How security updates are announced, and best practices for secure usage.

**Related Issues/PRs (if applicable)**

Related to the Road to v1.0 GA tracking issue envoyproxy/ai-gateway#2083.

**Special notes for reviewers (if applicable)**

A couple of operational follow-ups are needed for the policy to function fully:

- Private vulnerability reporting must be enabled in the repository settings so the advisory "Report a vulnerability" link works for external (non-maintainer) reporters.
- The envoy-ai-gateway-security Google Group should be configured to accept inbound mail from non-members while keeping its membership and archives private.

RELEASES.md still uses pre-1.0 wording and expresses the support window as "two releases" rather than the "6 months / quarterly" phrasing used here. Aligning it with this policy can be done as a follow-up so the two documents do not drift.
